### PR TITLE
Add sparse-avg suffix to metrics name

### DIFF
--- a/src/github.com/cloudfoundry-incubator/bits-service-performance-tests/app_push_test.go
+++ b/src/github.com/cloudfoundry-incubator/bits-service-performance-tests/app_push_test.go
@@ -22,7 +22,11 @@ var _ = Describe("Pushing an app", func() {
 				cf.Cf("push", appName, "-p", "assets/dora").Wait(cfPushTimeout)).
 				To(Exit(0))
 
-			statsdClient.Timing(metricsPrefix+"cf-push", time.Since(startTime).Seconds()*1000)
+			statsdClient.Timing(asSparseMetric("cf-push"), time.Since(startTime).Seconds()*1000)
 		}
 	})
 })
+
+func asSparseMetric(metricName string) string {
+	return metricsPrefix + metricName + ".sparse-avg"
+}


### PR DESCRIPTION
This enables us to see this metric even when specifying a time window of more than 24h in logmet.

Signed-off-by: Alexander Egurnov <egurnov@de.ibm.com>

@suhlig @MarcSchunk 