### PR TITLE
Set vcap password back to default

### DIFF
--- a/templates/standalone-blobstore-job.yml
+++ b/templates/standalone-blobstore-job.yml
@@ -21,6 +21,9 @@ instance_groups:
     env:
       bosh:
         keep_root_password: true
+        # https://github.com/cloudfoundry/bosh-softlayer-cpi-release/blob/master/docs/concourse_sample_v2_schema.yml#L65-L67
+        # http://www.starkandwayne.com/blog/hardening-the-vcap-users-password-on-bosh-vms/
+        # mkpasswd -s -m sha-512 -S 4gDD3aV0rdqlrKC c1oudc0w
         password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 
 properties:

--- a/templates/standalone-blobstore-job.yml
+++ b/templates/standalone-blobstore-job.yml
@@ -18,6 +18,10 @@ instance_groups:
           - (( grab $BLOBSTORE_JOB_IP ))
         default: [dns, gateway]
     update: {}
+    env:
+      bosh:
+        keep_root_password: true
+        password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 
 properties:
   system_domain: (( concat instance_groups.blobstore.networks.static.static_ips.0 ".xip.io" ))


### PR DESCRIPTION
Since bosh v260 the default vcap user password has changed, which causes tests to fail.
This restores the old passwords and makes the tests green again.