### PR TITLE
Restore default vcap password in bits-service VM

### DIFF
--- a/templates/standalone-bits-service-job.yml
+++ b/templates/standalone-bits-service-job.yml
@@ -16,6 +16,13 @@ instance_groups:
       static_ips:
         - (( grab $BITS_SERVICE_JOB_IP ))
       default: [dns, gateway]
+  env:
+    bosh:
+      keep_root_password: true
+      # https://github.com/cloudfoundry/bosh-softlayer-cpi-release/blob/master/docs/concourse_sample_v2_schema.yml#L65-L67
+      # http://www.starkandwayne.com/blog/hardening-the-vcap-users-password-on-bosh-vms/
+      # mkpasswd --method=sha-512 --salt="4gDD3aV0rdqlrKC" c1oudc0w
+      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 
 properties:
   bits-service:

--- a/templates/standalone-blobstore-job.yml
+++ b/templates/standalone-blobstore-job.yml
@@ -23,7 +23,7 @@ instance_groups:
         keep_root_password: true
         # https://github.com/cloudfoundry/bosh-softlayer-cpi-release/blob/master/docs/concourse_sample_v2_schema.yml#L65-L67
         # http://www.starkandwayne.com/blog/hardening-the-vcap-users-password-on-bosh-vms/
-        # mkpasswd -s -m sha-512 -S 4gDD3aV0rdqlrKC c1oudc0w
+        # mkpasswd --method=sha-512 --salt="4gDD3aV0rdqlrKC" c1oudc0w
         password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 
 properties:


### PR DESCRIPTION
Since bosh v260 the default vcap user password has changed, which causes tests to fail.
This restores the old password and makes the tests green again.