### PR TITLE
Fix unable to process links for deployment.

### DIFF
--- a/templates/bits-service-from-ci.yml
+++ b/templates/bits-service-from-ci.yml
@@ -11,6 +11,7 @@ jobs:
   - name: bits-service
     release: bits-service
   - name: route_registrar
+    consumes: { nats: nil }
     release: cf
   - name: consul_agent
     release: cf


### PR DESCRIPTION
With cf-release [v253](https://github.com/cloudfoundry/cf-release/releases/tag/v253) bosh links will be used on several lines of the bosh deployment. This make this change necessary for the bits_service config, too. Without this fix  the bosh deploy task will fail with this error:  

```
tarted preparing deployment > Preparing deployment. Failed: Unable to process links for deployment. Errors are:
   - Multiple instance groups provide links of type 'nats'. Cannot decide which one to use for instance group 'bits_service_z1'.
        cf-warden.nats_z1.nats.nats
        cf-warden.nats_z2.nats.nats (00:00:00)

Error 100: Unable to process links for deployment. Errors are:
   - Multiple instance groups provide links of type 'nats'. Cannot decide which one to use for instance group 'bits_service_z1'.
        cf-warden.nats_z1.nats.nats
        cf-warden.nats_z2.nats.nats
```