### PR TITLE
Makes sure singing user's credentials are synchronized between cc and bit-service.

### DIFF
--- a/templates/enable-bits.yml
+++ b/templates/enable-bits.yml
@@ -4,5 +4,5 @@ properties:
       enabled: true
       public_endpoint: (( concat "http://bits-service." properties.system_domain ))
       private_endpoint: http://bits-service.service.cf.internal
-      username: admin
-      password: <%= ENV.fetch('CF_PASSWORD', 'admin') %>
+      username: (( grab properties.bits-service.signing_users.0.username ))
+      password: (( grab properties.bits-service.signing_users.0.password ))


### PR DESCRIPTION
[#138931317]

Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>