### PR TITLE
Implemented upload limits for individual resource types

### DIFF
--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -8,6 +8,7 @@ templates:
   dns_health_check.erb:    bin/dns_health_check
 
   nginx.conf.erb:             config/nginx.conf
+  location_stub.conf.erb:     config/location_stub.conf
   bits_config.yml.erb:        config/bits_config.yml
   signing_users.erb:          config/signing_users
   app_stash_ca_cert.pem.erb:  config/certs/app_stash_ca_cert.pem
@@ -68,6 +69,9 @@ properties:
   bits-service.buildpacks.fog_connection:
     description: "Fog connection properties."
     default: null
+  bits-service.buildpacks.max_body_size:
+    default: "1536M"
+    description: "Maximum body size for nginx"
 
   bits-service.droplets.directory_key:
     description: "Directory (bucket) used to store droplet blobs."
@@ -93,6 +97,9 @@ properties:
   bits-service.droplets.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
     default: ""
+  bits-service.droplets.max_body_size:
+    default: "1536M"
+    description: "Maximum body size for nginx"
 
   bits-service.packages.directory_key:
     description: "Directory (bucket) used to store package blobs."
@@ -118,6 +125,9 @@ properties:
   bits-service.packages.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
     default: ""
+  bits-service.packages.max_body_size:
+    default: "1536M"
+    description: "Maximum body size for nginx"
 
   bits-service.app_stash.directory_key:
     description: "Directory (bucket) used to store app stash blobs."
@@ -143,6 +153,13 @@ properties:
   bits-service.app_stash.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
     default: ""
+  bits-service.app_stash.max_body_size:
+    default: "1536M"
+    description: "Maximum body size for nginx"
+
+  bits-service.buildpack_cache.max_body_size:
+    default: "1536M"
+    description: "Maximum body size for nginx"
 
   bits-service.max_body_size:
     default: "1536M"

--- a/jobs/bits-service/templates/location_stub.conf.erb
+++ b/jobs/bits-service/templates/location_stub.conf.erb
@@ -1,0 +1,19 @@
+# Pass altered request body to this location
+upload_pass @bits_service;
+upload_pass_args on;
+
+# Store files to this directory
+upload_store /var/vcap/data/bits-service/tmp/uploads;
+
+# No limit for output body forwarded
+upload_max_output_body_len 0;
+
+# Allow uploaded files to be read only by user
+upload_store_access user:r;
+
+# Set specified fields in request body
+upload_set_form_field "${upload_field_name}_name" $upload_file_name;
+upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
+
+# on any error, delete uploaded files
+upload_cleanup 400-505;

--- a/jobs/bits-service/templates/nginx.conf.erb
+++ b/jobs/bits-service/templates/nginx.conf.erb
@@ -61,61 +61,44 @@ http {
       add_header HTTP_X_VCAP_REQUEST_ID $HTTP_X_VCAP_REQUEST_ID;
     }
 
-    location ~ ^/buildpack_cache/entries {
+    location /buildpack_cache/entries {
       if ($request_method != PUT ) {
         proxy_pass http://bits_service;
         break;
       }
-
-      # Pass altered request body to this location
-      upload_pass @bits_service;
-      upload_pass_args on;
-
-      # Store files to this directory
-      upload_store /var/vcap/data/bits-service/tmp/uploads;
-
-      # No limit for output body forwarded
-      upload_max_output_body_len 0;
-
-      # Allow uploaded files to be read only by user
-      upload_store_access user:r;
-
-      # Set specified fields in request body
-      upload_set_form_field "${upload_field_name}_name" $upload_file_name;
-      upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
-
-      # on any error, delete uploaded files
-      upload_cleanup 400-505;
+      include "location_stub.conf";
+      client_max_body_size <%= p("bits-service.buildpack_cache.max_body_size") %>;
     }
-
-    location ~ ^/(buildpacks|packages|droplets|app_stash/entries) {
+    location /buildpacks {
       if ($content_type !~ "multipart/form-data") {
         proxy_pass http://bits_service;
       }
-      # PUT
-
-      # Pass altered request body to this location
-      upload_pass @bits_service;
-      upload_pass_args on;
-
-      # Store files to this directory
-      upload_store /var/vcap/data/bits-service/tmp/uploads;
-
-      # No limit for output body forwarded
-      upload_max_output_body_len 0;
-
-      # Allow uploaded files to be read only by user
-      upload_store_access user:r;
-
-      # Set specified fields in request body
-      upload_set_form_field "${upload_field_name}_name" $upload_file_name;
-      upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
-
-      # on any error, delete uploaded files
-      upload_cleanup 400-505;
+      include "location_stub.conf";
+      client_max_body_size <%= p("bits-service.buildpacks.max_body_size") %>;
+    }
+    location /packages {
+      if ($content_type !~ "multipart/form-data") {
+        proxy_pass http://bits_service;
+      }
+      include "location_stub.conf";
+      client_max_body_size <%= p("bits-service.packages.max_body_size") %>;
+    }
+    location /droplets {
+      if ($content_type !~ "multipart/form-data") {
+        proxy_pass http://bits_service;
+      }
+      include "location_stub.conf";
+      client_max_body_size <%= p("bits-service.droplets.max_body_size") %>;
+    }
+    location /app_stash/entries {
+      if ($content_type !~ "multipart/form-data") {
+        proxy_pass http://bits_service;
+      }
+      include "location_stub.conf";
+      client_max_body_size <%= p("bits-service.app_stash.max_body_size") %>;
     }
 
-    location ~ ^/app_stash {
+    location /app_stash {
       proxy_pass http://bits_service;
     }
 
@@ -185,25 +168,7 @@ http {
       }
       # PUT
 
-      # Pass altered request body to this location
-      upload_pass @bits_service;
-      upload_pass_args on;
-
-      # Store files to this directory
-      upload_store /var/vcap/data/bits-service/tmp/uploads;
-
-      # No limit for output body forwarded
-      upload_max_output_body_len 0;
-
-      # Allow uploaded files to be read only by user
-      upload_store_access user:r;
-
-      # Set specified fields in request body
-      upload_set_form_field "${upload_field_name}_name" $upload_file_name;
-      upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
-
-      # on any error, delete uploaded files
-      upload_cleanup 400-505;
+      include "location_stub.conf";
 
       proxy_pass_header HTTP_X_VCAP_REQUEST_ID;
       add_header HTTP_X_VCAP_REQUEST_ID $HTTP_X_VCAP_REQUEST_ID;

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -7,15 +7,15 @@ describe 'Bits-Release' do
       let(:tmp_dir) { Dir.mktmpdir }
       let(:filepath) { File.join(tmp_dir, 'large-file.zip') }
       let(:bits_to_upload) do
-        write_to_file(filepath, size_in_bytes: 2048 * 1024 + 1024)
+        write_to_file(filepath, size_in_bytes: 2048 * 1024 + 1024) #2M + 1K
         File.new(filepath)
       end
 
       it 'limits the size of the uploaded bits' do
-        # Note: this is actually an invalid request, because there is no POST for buildpacks
+        # Note: this is actually an invalid request, because there is no POST for root path
         # The reason this is working, is that nginx checks the body size before matching paths.
-        upload_body = { buildpack: bits_to_upload }
-        response = make_post_request '/buildpacks', upload_body
+        upload_body = { upload: bits_to_upload }
+        response = make_post_request '/', upload_body
         expect(response.code).to eq 413
       end
     end

--- a/spec/support/http.rb
+++ b/spec/support/http.rb
@@ -1,4 +1,8 @@
+require 'support/environment'
+
 module HttpHelpers
+  include EnvironmentHelpers
+
   def make_get_request(path, args={})
     try_catch { RestClient::Request.execute({ url: url(path), method: :get, verify_ssl: false }.merge(args)) }
   end

--- a/spec/upload_limit_spec.rb
+++ b/spec/upload_limit_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'Upload limits for resources' do
+
+  before :all do
+    @tmp_dir = Dir.mktmpdir
+  end
+  after :all do
+    FileUtils.remove_entry(@tmp_dir)
+  end
+
+  let(:filepath_small) { File.join(@tmp_dir, 'small-file.zip') }
+  let(:filepath_big) { File.join(@tmp_dir, 'big-file.zip') }
+  let(:file_small) do
+    write_to_file(filepath_small, size_in_bytes: 1024 * 1024) #1M
+    File.new(filepath_small)
+  end
+  let(:file_big) do
+    write_to_file(filepath_big, size_in_bytes: 6 * 1024 * 1024) #6M
+    File.new(filepath_big)
+  end
+
+  shared_examples 'limited file upload' do
+    context 'when the file is smaller then limit' do
+      it 'returns HTTP status code 201' do
+        response = make_put_request(resource_path, upload_body_small) if method == :PUT
+        response = make_post_request(resource_path, upload_body_small) if method == :POST
+
+        expect(response.code).to eq 201
+      end
+    end
+
+    context 'when the file is bigger then limit' do
+      it 'returns HTTP status code 413' do
+        response = make_put_request(resource_path, upload_body_big)
+        expect(response.code).to eq 413
+      end
+    end
+  end
+
+  context 'buildpack_cache/entries' do
+    let(:resource_path) { "/buildpack_cache/entries/#{SecureRandom.uuid}/cflinux" }
+    let(:upload_body_small) { { buildpack_cache: file_small } }
+    let(:upload_body_big) { { buildpack_cache: file_big } }
+    let(:method) { :PUT }
+
+    include_examples 'limited file upload'
+  end
+
+  context 'buildpacks' do
+    let(:resource_path) { "/buildpacks/#{SecureRandom.uuid}" }
+    let(:upload_body_small) { { buildpack: file_small } }
+    let(:upload_body_big) { { buildpack: file_big } }
+    let(:method) { :PUT }
+
+    include_examples 'limited file upload'
+  end
+
+  context 'packages' do
+    let(:resource_path) { "/packages/#{SecureRandom.uuid}" }
+    let(:upload_body_small) { { package: file_small } }
+    let(:upload_body_big) { { package: file_big } }
+    let(:method) { :PUT }
+
+    include_examples 'limited file upload'
+  end
+
+  context 'droplets' do
+    let(:resource_path) { "/droplets/#{SecureRandom.uuid}/#{SecureRandom.uuid}" }
+    let(:upload_body_small) { { droplet: file_small } }
+    let(:upload_body_big) { { droplet: file_big } }
+    let(:method) { :PUT }
+
+    include_examples 'limited file upload'
+  end
+
+  context 'app_stash/entries' do
+    let(:resource_path) { "/app_stash/entries" }
+    let(:upload_body_small) { { application: File.new(File.expand_path('../assets/app.zip', __FILE__)) } }
+    let(:upload_body_big) { { application: file_big } }
+    let(:method) { :POST }
+
+    include_examples 'limited file upload'
+  end
+end

--- a/templates/body-size-stub.yml
+++ b/templates/body-size-stub.yml
@@ -1,3 +1,13 @@
 properties:
   bits-service:
     max_body_size: 2M
+    app_stash:
+      max_body_size: 5M
+    buildpacks:
+      max_body_size: 5M
+    droplets:
+      max_body_size: 5M
+    packages:
+      max_body_size: 5M
+    buildpack_cache:
+      max_body_size: 5M


### PR DESCRIPTION
Introduced configuration parameters for each of buildpacks, droplets, packages,
app_stash/entries and buildpack_cache/entries. Implemented limiting by overriding
global `client_max_body_size` config in each upload location in nginx.

Updated test for global upload limit to go to `/` so that it does not match any
of the overriden locations.

Also, use prefix locations for upload paths instead of regex locations.

[#118231563]

Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>
Signed-off-by: Alexander Egurnov <egurnov@de.ibm.com>