### PR TITLE
Use HTTP 507 Error to indicate that local blobstore disk is full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ src/github.com/codegangsta/
 src/github.com/vito/
 .envrc
 .vscode
+.rake_t_cache

--- a/scripts/add-route
+++ b/scripts/add-route
@@ -2,22 +2,18 @@
 
 set -x
 
-old_ips="10.244.0.0/19"
 ips="10.250.0.0/16"
 gw="192.168.50.4"
 
 echo "Adding the following route entry to your local route table to enable direct container access: $ips via $gw. Your sudo password may be required." > /dev/null
 
 if [ `uname` = "Darwin" ]; then
-  sudo route delete -net $old_ips $gw
   sudo route delete -net $ips     $gw
   sudo route add    -net $ips     $gw
 elif [ `uname` = "Linux" ]; then
   if type route > /dev/null 2>&1; then
-    sudo route del -net $old_ips gw $gw
     sudo route add -net $ips     gw $gw
   elif type ip > /dev/null 2>&1; then
-    sudo ip route del $old_ips via $gw
     sudo ip route add $ips     via $gw
   else
     echo "ERROR adding route"

--- a/scripts/generate-test-bosh-lite-manifest-webdav
+++ b/scripts/generate-test-bosh-lite-manifest-webdav
@@ -5,4 +5,5 @@ cd $(dirname $0)/..
 
 ./scripts/generate-test-bosh-lite-manifest \
   ./templates/webdav.yml \
-  ./templates/bits-release-network-webdav.yml
+  ./templates/bits-release-network-webdav.yml \
+  ./templates/bits-service-system-tests.yml

--- a/spec/app_stash_spec.rb
+++ b/spec/app_stash_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples'
 
 describe 'app_stash endpoint' do
   let(:blobstore_client) { backend_client(:app_stash) }
@@ -44,6 +45,27 @@ describe 'app_stash endpoint' do
         response = make_post_request endpoint, request_body
         expect(response.code).to eq 400
       end
+    end
+
+    context 'when the files are really new and space needs to be allocated' do
+      let(:tmp_dir) { Dir.mktmpdir }
+      let(:filepath) { File.join(tmp_dir, 'file') }
+      let(:zip_path) { File.join(tmp_dir, 'file.zip') }
+      let(:request_body) do
+        { application: File.new(zip_path) }
+      end
+
+      before do
+        write_random_to_file(filepath)
+        `zip #{zip_path} #{filepath}`
+      end
+
+      after do
+        File.unlink zip_path
+        File.unlink filepath
+      end
+
+      include_examples 'when blobstore disk is full', :app_stash
     end
   end
 

--- a/spec/buildpack_cache_spec.rb
+++ b/spec/buildpack_cache_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples'
 
 describe 'buildpack cache resource', type: :integration do
   let(:zip_filepath) { File.expand_path('../assets/empty.zip', __FILE__) }
@@ -29,6 +30,8 @@ describe 'buildpack cache resource', type: :integration do
         expect(response.code).to eq(415)
       end
     end
+
+    include_examples 'when blobstore disk is full', :buildpack_cache
   end
 
   describe 'DELETE specific entry for /buildpack_cache/entries/:app_guid/:stack_name' do

--- a/spec/buildpacks_spec.rb
+++ b/spec/buildpacks_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples'
 
 describe 'buildpacks resource', type: :integration do
   let(:guid) { SecureRandom.uuid }
@@ -25,6 +26,8 @@ describe 'buildpacks resource', type: :integration do
       make_put_request resource_path, upload_body
       expect(blobstore_client.key_exist?(guid)).to eq(true)
     end
+
+    include_examples 'when blobstore disk is full', :buildpacks
   end
 
   describe 'GET /buildpacks/:guid' do

--- a/spec/droplets_spec.rb
+++ b/spec/droplets_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples'
 
 describe 'droplets resource' do
   let(:guid) { "#{SecureRandom.uuid}/#{SecureRandom.uuid}" }
@@ -25,6 +26,8 @@ describe 'droplets resource' do
       make_put_request resource_path, upload_body
       expect(blobstore_client.key_exist?(guid)).to eq(true)
     end
+
+    include_examples 'when blobstore disk is full', :droplets
 
     context 'when the request body is invalid' do
       let(:tempfile) {

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples'
 
 describe 'packages resource' do
   let(:guid) { SecureRandom.uuid }
@@ -6,9 +7,7 @@ describe 'packages resource' do
   let(:upload_body) { { package: zip_file } }
   let(:blobstore_client) { backend_client(:packages) }
   let(:zip_filepath) { File.expand_path('../assets/empty.zip', __FILE__) }
-  let(:zip_file) do
-    File.new(zip_filepath)
-  end
+  let(:zip_file) { File.new(zip_filepath) }
   let(:existing_guid) do
     SecureRandom.uuid.tap do |guid|
       make_put_request "/packages/#{guid}", upload_body
@@ -35,6 +34,8 @@ describe 'packages resource' do
           expect(response.code).to eq 400
         end
       end
+
+      include_examples 'when blobstore disk is full', :packages
     end
 
     context 'when package is duplicated' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+shared_examples 'when blobstore disk is full' do |resource|
+  context 'when blobstore disk is full', if: blobstore_provider(resource) == 'local' do
+    before { expect(blobstore_client.fill_storage).to be true }
+    after { blobstore_client.clear_storage }
+
+    it 'returns HTTP status 507' do
+      response = case resource
+                 when :app_stash
+                   make_post_request endpoint, request_body
+                 when :buildpack_cache
+                   make_put_request path, upload_body
+                 when :buildpacks, :droplets, :packages
+                   make_put_request resource_path, upload_body
+                 else
+                   warn 'Unknown resource type'
+                 end
+
+      expect(response.code).to eq 507
+      expect(response.body).not_to be_empty
+      payload = JSON(response.body)
+      expect(payload['code']).to eq 500000
+    end
+  end
+end

--- a/spec/support/backend.rb
+++ b/spec/support/backend.rb
@@ -3,7 +3,11 @@ require_relative './backend/s3'
 require_relative './backend/local'
 require_relative './backend/webdav'
 
+require_relative 'environment'
+
 module BackendHelpers
+  include EnvironmentHelpers
+
   def backend_client(resource_type)
     resource_type = resource_type.to_s
 

--- a/spec/support/backend/local.rb
+++ b/spec/support/backend/local.rb
@@ -1,8 +1,12 @@
 require 'net/sftp'
 
+require_relative './remote_commands'
+
 module Backend
   module Local
     class Client < Backend::ClientBase
+      include RemoteCommands
+
       def initialize(root_path, directory_key, path_prefix, job_ip)
         @root_path = root_path
         @directory_key = directory_key
@@ -13,23 +17,12 @@ module Backend
 
       def key_exist?(guid)
         path = File.join(root_path, directory_key, path_for_guid(guid))
-
         remote_path_exists?(job_ip, path)
       end
 
       private
 
       attr_reader :root_path, :directory_key, :job_ip
-
-      def remote_path_exists?(ip, path)
-        Net::SFTP.start(ip, 'vcap', password: 'c1oudc0w') do |sftp|
-          sftp.stat(path) do |response|
-            return true if response.ok?
-          end
-        end
-
-        false
-      end
     end
   end
 end

--- a/spec/support/backend/remote_commands.rb
+++ b/spec/support/backend/remote_commands.rb
@@ -1,0 +1,34 @@
+require 'net/ssh'
+
+module RemoteCommands
+  def exec_remote_cmd(cmd, user='vcap', password='c1oudc0w')
+    output = ''
+
+    Net::SSH.start(@job_ip, user, password: password) do |ssh|
+      output = ssh.exec!("echo '#{password}' | sudo -S #{cmd}")
+    end
+
+    output
+  end
+
+  def remote_path_exists?(ip, path, user='vcap', password='c1oudc0w')
+    Net::SFTP.start(ip, user, password: password) do |sftp|
+      sftp.stat(path) do |response|
+        return true if response.ok?
+      end
+    end
+
+    false
+  end
+
+  def fill_storage(size='50G')
+    # 6K (6 * 1024) of 1M (1024 * 1024) bytes blocks is a 6Gb file. dd will stop when it runs out of space.
+    # exec_remote_cmd "dd if=/dev/zero of=#{@root_path}/dummyblob bs=1M count=#{size}"
+    output = exec_remote_cmd "fallocate -l #{size} #{@root_path}/dummyblob"
+    output.include? 'No space left on device'
+  end
+
+  def clear_storage
+    exec_remote_cmd "rm #{@root_path}/dummyblob"
+  end
+end

--- a/spec/support/file.rb
+++ b/spec/support/file.rb
@@ -4,4 +4,10 @@ module FileHelpers
     tf.write('A' * size_in_bytes)
     tf.close
   end
+
+  def write_random_to_file(file_path, size_in_bytes: 1024)
+    tf = File.open(file_path, 'w')
+    tf.write(Random.new.bytes(size_in_bytes))
+    tf.close
+  end
 end

--- a/templates/bits-service-system-tests.yml
+++ b/templates/bits-service-system-tests.yml
@@ -4,3 +4,9 @@ jobs:
     bosh:
       keep_root_password: true
       password: "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0"
+  persistent_disk: 1024
+- name: blobstore
+  env:
+    bosh:
+      keep_root_password: true
+      password: "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0"

--- a/templates/standalone-properties-local.yml
+++ b/templates/standalone-properties-local.yml
@@ -1,3 +1,7 @@
+instance_groups:
+- name: bits-service
+  persistent_disk_type: tiny
+
 properties:
   bits-service:
     buildpacks:


### PR DESCRIPTION
We extended CloudFoundry API errors with 500000: NoSpaceOnDevice.
When local blobstore is used and the filesystem where it is located
is full, HTTP 507 will be returned.

This does not affect how nginx processes uploads. When nginx encounters
problems with its temporary storage, which may be in the same filesystem,
it will return a different error before request reaches bits-service.

[#115615679]

Signed-off-by: Alexander Egurnov <egurnov@de.ibm.com>
Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>