### PR TITLE
Implement package status updates for CloudController

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,72 @@
 
 A [BOSH](http://docs.cloudfoundry.org/bosh/) release for deploying the [bits-service](https://github.com/cloudfoundry-incubator/bits-service).
 
-# Deployment
+## Deployment
 
-## Deploy a CF on BOSH Lite with bits-service enabled
+### Deploy a CF on BOSH Lite with bits-service enabled
 
 **Important**: We assume that you already deployed a CF to bosh-lite, with the deployment manifest in `cf-release/bosh-lite/deployments/cf.yml`.
 
 1. Grab the bits-service-release
 
-  ```
-  git clone git@github.com:cloudfoundry-incubator/bits-service-release.git
-  cd bits-service-release/
-  ./scripts/update
-  ```
+    ```
+    git clone git@github.com:cloudfoundry-incubator/bits-service-release.git
+    cd bits-service-release/
+    ./scripts/update
+    ```
 
 1. Install `spruce` which is used to generate the bosh-lite manifest:
 
-  ```
-  brew install starkandwayne/cf/spruce
-  ```
+    ```
+    brew install starkandwayne/cf/spruce
+    ```
 
 1. Generate the deployment manifest. Pass the backend to be used (`local`, `s3`, or `webdav`) as parameter. For example, for a bits-service with local backend:
 
-  ```
-  ./scripts/generate-cf-with-bits-service-enabled-bosh-lite-manifest local
-  ```
+    ```
+    ./scripts/generate-cf-with-bits-service-enabled-bosh-lite-manifest local
+    ```
+
+    When targeting an S3 blobstore, the following environment variables are required to be set. Otherwise you can skip this step.
+
+    ```
+    export BITS_DIRECTORY_KEY=
+    export AWS_ACCESS_KEY_ID=
+    export AWS_SECRET_ACCESS_KEY=
+    export BITS_AWS_REGION=
+    ```
 
 1. Deploy
 
-  ```
-  bosh create release --force && bosh upload release && bosh -n deploy
-  ```
+    ```
+    bosh create release --force && bosh upload release && bosh -n deploy
+    ```
 
-  When prompted for the name of the bits-service release, accept the default `bits-service`.
+    When prompted for the name of the bits-service release, accept the default `bits-service`.
 
-# Run Tests
+## Run Tests
+
+To run bits-service tests, you need to deploy it with upload size limits set to lower values.
+
+Generate deployment manifest with `--size-limits` and deploy.
+```
+./scripts/generate-cf-with-bits-service-enabled-bosh-lite-manifest local --size-limits
+```
+Be advised that the deployment should have succeeded before at least once, otherwise CloudFoundry post-install scripts will fail to run with this stricter limits.
 
 Configure test execution:
 
 ```sh
 export BITS_SERVICE_PRIVATE_ENDPOINT_IP=10.244.0.74
-export BITS_SERVICE_MANIFEST=./deployments/bits-service-release.yml
-export GOPATH=$PWD
+export BITS_SERVICE_MANIFEST=./deployments/cf-with-bits-service-enabled.yml
 
 ./scripts/add-route
+```
+
+The following two lines need to be present in your `/etc/hosts` to run the tests:
+```
+10.244.0.74 bits-service.service.cf.internal bits-service.bosh-lite.com
+10.244.0.130 blobstore.service.cf.internal
 ```
 
 Then run:
@@ -55,18 +77,31 @@ bundle install
 bundle exec rake
 ```
 
-If you run into errors like `Net::SSH::HostKeyMismatch`, you need to remove the offending entry from `~/.ssh/known_hosts`.
-
-# CI Pipeline
+## CI Pipeline
 
 The pipeline is publicly visible at [flintstone.ci.cf-app.com](https://flintstone.ci.cf-app.com). The sources are located at [bits-service-ci](https://github.com/cloudfoundry-incubator/bits-service-ci).
 
-# Troubleshooting
-## Failed TCP connection problem
-If you run into connection errors like this one: `
-Failed to open TCP connection to 10.250.0.2.xip.io:80 (getaddrinfo: nodename nor servname provided, or not known)`
+## Certificate generation
+We used CA credentials as provided by `cf-release/templates/bosh-lite-fixtures/server-ca.{crt,key}`. To generate bits-service certificate and key, the following commands have been issued:
+```console
+certstrap init --key server-ca.key --cn 'bbsCA'
+certstrap request-cert --passphrase '' --common-name bits-service
+certstrap sign bits-service --CA bbsCA
+```
 
-Try cleaning your DNS cache. On MacOS Sierra (10.12) you can do this with:
+You can pick up you new credentials from `./out/bits-service.{crt,key}`.
+
+Pay extra attention to CA's common name: it absolutely needs to be 'bbsCA' for the certificates to work correctly.
+
+## Troubleshooting
+### Failed TCP connections
+If you run into connection errors like this one: `Failed to open TCP connection to 10.250.0.2.xip.io:80 (getaddrinfo: nodename nor servname provided, or not known)` try cleaning your DNS cache. On MacOS Sierra (10.12) you can do this with:
 ```console
 sudo killall -HUP mDNSResponder
+```
+
+### Failed SSH connections
+If you run into errors like `Net::SSH::HostKeyMismatch`, you need to remove the offending entry from `~/.ssh/known_hosts`.
+```console
+ssh-keygen -R $offending_ip
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A [BOSH](http://docs.cloudfoundry.org/bosh/) release for deploying the [bits-ser
 
 1. Grab the bits-service-release
 
-    ```
+    ```sh
     git clone git@github.com:cloudfoundry-incubator/bits-service-release.git
     cd bits-service-release/
     ./scripts/update
@@ -30,7 +30,7 @@ A [BOSH](http://docs.cloudfoundry.org/bosh/) release for deploying the [bits-ser
 
     When targeting an S3 blobstore, the following environment variables are required to be set. Otherwise you can skip this step.
 
-    ```
+    ```sh
     export BITS_DIRECTORY_KEY=
     export AWS_ACCESS_KEY_ID=
     export AWS_SECRET_ACCESS_KEY=
@@ -39,7 +39,7 @@ A [BOSH](http://docs.cloudfoundry.org/bosh/) release for deploying the [bits-ser
 
 1. Deploy
 
-    ```
+    ```sh
     bosh create release --force && bosh upload release && bosh -n deploy
     ```
 
@@ -83,7 +83,7 @@ The pipeline is publicly visible at [flintstone.ci.cf-app.com](https://flintston
 
 ## Certificate generation
 We used CA credentials as provided by `cf-release/templates/bosh-lite-fixtures/server-ca.{crt,key}`. To generate bits-service certificate and key, the following commands have been issued:
-```console
+```sh
 certstrap init --key server-ca.key --cn 'bbsCA'
 certstrap request-cert --passphrase '' --common-name bits-service
 certstrap sign bits-service --CA bbsCA
@@ -96,12 +96,12 @@ Pay extra attention to CA's common name: it absolutely needs to be 'bbsCA' for t
 ## Troubleshooting
 ### Failed TCP connections
 If you run into connection errors like this one: `Failed to open TCP connection to 10.250.0.2.xip.io:80 (getaddrinfo: nodename nor servname provided, or not known)` try cleaning your DNS cache. On MacOS Sierra (10.12) you can do this with:
-```console
+```sh
 sudo killall -HUP mDNSResponder
 ```
 
 ### Failed SSH connections
 If you run into errors like `Net::SSH::HostKeyMismatch`, you need to remove the offending entry from `~/.ssh/known_hosts`.
-```console
+```sh
 ssh-keygen -R $offending_ip
 ```

--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -68,7 +68,6 @@ properties:
     default: ""
   bits-service.buildpacks.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
-    default: ""
   bits-service.buildpacks.fog_connection:
     description: "Fog connection properties."
     default: null
@@ -99,7 +98,6 @@ properties:
     default: ""
   bits-service.droplets.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
-    default: ""
   bits-service.droplets.max_body_size:
     default: "1536M"
     description: "Maximum body size for nginx"
@@ -127,7 +125,6 @@ properties:
     default: ""
   bits-service.packages.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
-    default: ""
   bits-service.packages.max_body_size:
     default: "1536M"
     description: "Maximum body size for nginx"
@@ -155,7 +152,6 @@ properties:
     default: ""
   bits-service.app_stash.webdav_config.ca_cert:
     description: "The ca cert to use when communicating with webdav"
-    default: ""
   bits-service.app_stash.max_body_size:
     default: "1536M"
     description: "Maximum body size for nginx"

--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -15,6 +15,9 @@ templates:
   buildpacks_ca_cert.pem.erb: config/certs/buildpacks_ca_cert.pem
   droplets_ca_cert.pem.erb:   config/certs/droplets_ca_cert.pem
   packages_ca_cert.pem.erb:   config/certs/packages_ca_cert.pem
+  mutual_ca_cert.pem.erb:     config/certs/mutual_ca_cert.pem
+  mutual_client_cert.pem.erb: config/certs/mutual_client_cert.pem
+  mutual_client_key.pem.erb:  config/certs/mutual_client_key.pem
 
 packages:
   - ruby-2.3
@@ -201,3 +204,16 @@ properties:
   bits-service.nginx.metrics_log_destination:
     description: "Nginx metrics log destination."
     default: "/var/vcap/sys/log/nginx_bits/metrics.log"
+
+  bits-service.cc_updates.cc_url:
+    description: "CloudController endpoint for sending package status updates"
+    default: "https://cloud-controller-ng.service.cf.internal:9023/internal/v4/"
+  bits-service.cc_updates.ca_cert:
+    description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"
+    default: ""
+  bits-service.cc_updates.client_cert:
+    description: "PEM-encoded certificate for secure, mutually authenticated TLS communication"
+    default: ""
+  bits-service.cc_updates.client_key:
+    description: "PEM-encoded key for secure, mutually authenticated TLS communication"
+    default: ""

--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -210,10 +210,7 @@ properties:
     default: "https://cloud-controller-ng.service.cf.internal:9023/internal/v4/"
   bits-service.cc_updates.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"
-    default: ""
   bits-service.cc_updates.client_cert:
     description: "PEM-encoded certificate for secure, mutually authenticated TLS communication"
-    default: ""
   bits-service.cc_updates.client_key:
     description: "PEM-encoded key for secure, mutually authenticated TLS communication"
-    default: ""

--- a/jobs/bits-service/templates/app_stash_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/app_stash_ca_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.app_stash.webdav_config.ca_cert") %>
+<% if_p("bits-service.app_stash.webdav_config.ca_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/bits_config.yml.erb
+++ b/jobs/bits-service/templates/bits_config.yml.erb
@@ -6,7 +6,7 @@ buildpacks:
     private_endpoint: <%= p("bits-service.buildpacks.webdav_config.private_endpoint") %>
     username: <%= p("bits-service.buildpacks.webdav_config.username") %>
     password: <%= p("bits-service.buildpacks.webdav_config.password") %>
-    <% if p("bits-service.buildpacks.webdav_config.ca_cert") != "" && p("bits-service.buildpacks.webdav_config.ca_cert") != nil %>
+    <% if_p("bits-service.buildpacks.webdav_config.ca_cert") do %>
     ca_cert_path: "/var/vcap/jobs/bits-service/config/certs/buildpacks_ca_cert.pem"
     <% end %>
   fog_connection: <%= p("bits-service.buildpacks.fog_connection", {}).to_json %>
@@ -18,7 +18,7 @@ droplets:
     private_endpoint: <%= p("bits-service.droplets.webdav_config.private_endpoint") %>
     username: <%= p("bits-service.droplets.webdav_config.username") %>
     password: <%= p("bits-service.droplets.webdav_config.password") %>
-    <% if p("bits-service.droplets.webdav_config.ca_cert") != "" && p("bits-service.droplets.webdav_config.ca_cert") != nil %>
+    <% if_p("bits-service.droplets.webdav_config.ca_cert") do %>
     ca_cert_path: "/var/vcap/jobs/bits-service/config/certs/droplets_ca_cert.pem"
     <% end %>
   fog_connection: <%= p("bits-service.droplets.fog_connection", {}).to_json %>
@@ -30,7 +30,7 @@ packages:
     private_endpoint: <%= p("bits-service.packages.webdav_config.private_endpoint") %>
     username: <%= p("bits-service.packages.webdav_config.username") %>
     password: <%= p("bits-service.packages.webdav_config.password") %>
-    <% if p("bits-service.packages.webdav_config.ca_cert") != "" && p("bits-service.packages.webdav_config.ca_cert") != nil %>
+    <% if_p("bits-service.packages.webdav_config.ca_cert") do %>
     ca_cert_path: "/var/vcap/jobs/bits-service/config/certs/packages_ca_cert.pem"
     <% end %>
   fog_connection: <%= p("bits-service.packages.fog_connection", {}).to_json %>
@@ -42,7 +42,7 @@ app_stash:
     private_endpoint: <%= p("bits-service.app_stash.webdav_config.private_endpoint") %>
     username: <%= p("bits-service.app_stash.webdav_config.username") %>
     password: <%= p("bits-service.app_stash.webdav_config.password") %>
-    <% if p("bits-service.app_stash.webdav_config.ca_cert") != "" && p("bits-service.app_stash.webdav_config.ca_cert") != nil %>
+    <% if_p("bits-service.app_stash.webdav_config.ca_cert") do %>
     ca_cert_path: "/var/vcap/jobs/bits-service/config/certs/app_stash_ca_cert.pem"
     <% end %>
   fog_connection: <%= p("bits-service.app_stash.fog_connection", {}).to_json %>
@@ -56,7 +56,7 @@ logging:
 public_endpoint: <%= p("bits-service.public_endpoint") %>
 secret: <%= p("bits-service.secret") %>
 skip_cert_verify: true
-<% if_p("bits-service.cc_updates.ca_cert", "bits-service.cc_updates.client_cert", "bits-service.cc_updates.client_key") do |ca_cert, client_cert, client_key| %>
+<% if_p("bits-service.cc_updates.ca_cert", "bits-service.cc_updates.client_cert", "bits-service.cc_updates.client_key") do %>
 cc_updates:
   cc_url: <%= p("bits-service.cc_updates.cc_url") %>
   ca_cert: "/var/vcap/jobs/bits-service/config/certs/mutual_ca_cert.pem"

--- a/jobs/bits-service/templates/bits_config.yml.erb
+++ b/jobs/bits-service/templates/bits_config.yml.erb
@@ -56,9 +56,7 @@ logging:
 public_endpoint: <%= p("bits-service.public_endpoint") %>
 secret: <%= p("bits-service.secret") %>
 skip_cert_verify: true
-<% if p("bits-service.cc_updates.ca_cert") != "" && p("bits-service.cc_updates.ca_cert") != nil &&
-  p("bits-service.cc_updates.client_cert") != "" && p("bits-service.cc_updates.client_cert") != nil &&
-  p("bits-service.cc_updates.client_key") != "" && p("bits-service.cc_updates.client_key") != nil %>
+<% if_p("bits-service.cc_updates.ca_cert", "bits-service.cc_updates.client_cert", "bits-service.cc_updates.client_key") do |ca_cert, client_cert, client_key| %>
 cc_updates:
   cc_url: <%= p("bits-service.cc_updates.cc_url") %>
   ca_cert: "/var/vcap/jobs/bits-service/config/certs/mutual_ca_cert.pem"

--- a/jobs/bits-service/templates/bits_config.yml.erb
+++ b/jobs/bits-service/templates/bits_config.yml.erb
@@ -56,3 +56,12 @@ logging:
 public_endpoint: <%= p("bits-service.public_endpoint") %>
 secret: <%= p("bits-service.secret") %>
 skip_cert_verify: true
+<% if p("bits-service.cc_updates.ca_cert") != "" && p("bits-service.cc_updates.ca_cert") != nil &&
+  p("bits-service.cc_updates.client_cert") != "" && p("bits-service.cc_updates.client_cert") != nil &&
+  p("bits-service.cc_updates.client_key") != "" && p("bits-service.cc_updates.client_key") != nil %>
+cc_updates:
+  cc_url: <%= p("bits-service.cc_updates.cc_url") %>
+  ca_cert: "/var/vcap/jobs/bits-service/config/certs/mutual_ca_cert.pem"
+  client_cert: "/var/vcap/jobs/bits-service/config/certs/mutual_client_cert.pem"
+  client_key: "/var/vcap/jobs/bits-service/config/certs/mutual_client_key.pem"
+<% end %>

--- a/jobs/bits-service/templates/buildpacks_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/buildpacks_ca_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.buildpacks.webdav_config.ca_cert") %>
+<% if_p("bits-service.buildpacks.webdav_config.ca_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/droplets_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/droplets_ca_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.droplets.webdav_config.ca_cert") %>
+<% if_p("bits-service.droplets.webdav_config.ca_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/mutual_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/mutual_ca_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.cc_updates.ca_cert") %>
+<% if_p("bits-service.cc_updates.ca_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/mutual_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/mutual_ca_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p("bits-service.cc_updates.ca_cert") %>

--- a/jobs/bits-service/templates/mutual_client_cert.pem.erb
+++ b/jobs/bits-service/templates/mutual_client_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p("bits-service.cc_updates.client_cert") %>

--- a/jobs/bits-service/templates/mutual_client_cert.pem.erb
+++ b/jobs/bits-service/templates/mutual_client_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.cc_updates.client_cert") %>
+<% if_p("bits-service.cc_updates.client_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/mutual_client_key.pem.erb
+++ b/jobs/bits-service/templates/mutual_client_key.pem.erb
@@ -1,0 +1,1 @@
+<%= p("bits-service.cc_updates.client_key") %>

--- a/jobs/bits-service/templates/mutual_client_key.pem.erb
+++ b/jobs/bits-service/templates/mutual_client_key.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.cc_updates.client_key") %>
+<% if_p("bits-service.cc_updates.client_key") do |value| %>
+<%= value %>
+<% end %>

--- a/jobs/bits-service/templates/packages_ca_cert.pem.erb
+++ b/jobs/bits-service/templates/packages_ca_cert.pem.erb
@@ -1,1 +1,3 @@
-<%= p("bits-service.packages.webdav_config.ca_cert") %>
+<% if_p("bits-service.packages.webdav_config.ca_cert") do |value| %>
+<%= value %>
+<% end %>

--- a/scripts/generate-cf-with-bits-service-enabled-bosh-lite-manifest
+++ b/scripts/generate-cf-with-bits-service-enabled-bosh-lite-manifest
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 BLOBSTORE_TYPE=${1}
+SIZE_LIMITS=${2}
 
 if [ -z "$BLOBSTORE_TYPE" ]; then
   >&2 echo "Please provide a BLOBSTORE_TYPE {local,s3,webdav}"
@@ -18,29 +19,39 @@ if [ ! -f "$cf_yml" ]; then
   exit 1
 fi
 
-if [ "${BLOBSTORE_TYPE}" == "webdav" ]; then
-  spruce merge "$cf_yml" \
-    ./templates/bits-service-from-ci.yml \
-    ./templates/cc-blobstore-properties.yml \
-    ./templates/bits-service-signing-properties.yml \
-    ./templates/director_uuid.yml \
-    ./templates/acceptance_test_properties.yml \
-    ./templates/enable-bits.yml \
-    ./templates/bits-network-bosh-lite.yml \
-    ./templates/webdav.yml \
-    ./templates/webdav-blobstore-support.yml \
-    > deployments/cf-with-bits-service-enabled.yml
+templates="
+  ./templates/bits-service-from-ci.yml
+  ./templates/cc-blobstore-properties.yml
+  ./templates/bits-service-signing-properties.yml
+  ./templates/director_uuid.yml
+  ./templates/acceptance_test_properties.yml
+  ./templates/enable-bits.yml
+  ./templates/bits-network-bosh-lite.yml
+  ./templates/mutual_tls.yml
+  ./templates/bits_service_tests.yml
+"
+
+if [ "${SIZE_LIMITS}" == "--size-limits" ]; then
+  echo "Including size limits for blobstore uploads"
+  templates="${templates}
+    ./templates/body-size-stub.yml
+  "
 else
-  spruce merge "$cf_yml" \
-    ./templates/bits-service-from-ci.yml \
-    ./templates/cc-blobstore-properties.yml \
-    ./templates/bits-service-signing-properties.yml \
-    ./templates/director_uuid.yml \
-    ./templates/acceptance_test_properties.yml \
-    ./templates/enable-bits.yml \
-    ./templates/bits-network-bosh-lite.yml \
-    ./templates/${BLOBSTORE_TYPE}.yml \
-    > deployments/cf-with-bits-service-enabled.yml
+  echo "Skipping size limits for blobstore uploads"
 fi
+
+if [ "${BLOBSTORE_TYPE}" == "webdav" ]; then
+  templates="${templates}
+    ./templates/webdav.yml
+    ./templates/webdav-blobstore-support.yml
+  "
+else
+  templates="${templates}
+    ./templates/${BLOBSTORE_TYPE}.yml
+  "
+fi
+
+spruce merge "$cf_yml" ${templates} \
+  > deployments/cf-with-bits-service-enabled.yml
 
 bosh deployment deployments/cf-with-bits-service-enabled.yml

--- a/spec/cf_spec.rb
+++ b/spec/cf_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require_relative 'support/cf.rb'
+require 'support/cf.rb'
 
 describe 'CF test', if: cc_updates_enabled? do
   subject(:cf_client) do

--- a/spec/cf_spec.rb
+++ b/spec/cf_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require_relative 'support/cf.rb'
+
+describe 'CF test', if: cc_updates_enabled? do
+  subject(:cf_client) do
+    CFClient::Client.new(cc_api_url, cc_user, cc_password)
+  end
+
+  it 'can get a token' do
+    token = cf_client.send(:fetch_token)
+    expect(token).to_not be_nil
+    expect(token).to_not be_empty
+  end
+
+  it 'can create an org' do
+    begin
+      org_id = cf_client.create_org
+      expect(org_id).to_not be_empty
+      space_id = cf_client.create_space(org_id)
+      expect(space_id).to_not be_empty
+      app_id = cf_client.create_app(space_id)
+      expect(app_id).to_not be_empty
+      package_id = cf_client.create_package(app_id)
+      expect(package_id).to_not be_empty
+    ensure
+      cf_client.delete_org(org_id)
+    end
+    expect(cf_client.get_org(org_id)['error_code']).to eq('CF-OrganizationNotFound')
+  end
+end

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'shared_examples'
 require 'json'
+require 'support/cf.rb'
 
 describe 'packages resource' do
   let(:resource_path) { "/packages/#{guid}" }

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -1,16 +1,45 @@
 require 'spec_helper'
 require 'shared_examples'
+require 'json'
 
 describe 'packages resource' do
-  let(:guid) { SecureRandom.uuid }
   let(:resource_path) { "/packages/#{guid}" }
   let(:upload_body) { { package: zip_file } }
   let(:blobstore_client) { backend_client(:packages) }
   let(:zip_filepath) { File.expand_path('../assets/empty.zip', __FILE__) }
   let(:zip_file) { File.new(zip_filepath) }
+  let(:guid) do
+    if !cc_updates_enabled?
+      SecureRandom.uuid
+    else
+      @cf_client.create_package(@app_id)
+    end
+  end
   let(:existing_guid) do
-    SecureRandom.uuid.tap do |guid|
+    if !cc_updates_enabled?
+      SecureRandom.uuid
+    else
+      @cf_client.create_package(@app_id)
+    end.tap do |guid|
       make_put_request "/packages/#{guid}", upload_body
+    end
+  end
+
+  before :all do
+    if cc_updates_enabled?
+      @cf_client = CFClient::Client.new(cc_api_url, cc_user, cc_password)
+      @org_id = @cf_client.create_org
+      expect(@org_id).to_not be_empty
+      @space_id = @cf_client.create_space(@org_id)
+      expect(@space_id).to_not be_empty
+      @app_id = @cf_client.create_app(@space_id)
+      expect(@app_id).to_not be_empty
+    end
+  end
+  after :all do
+    if cc_updates_enabled?
+      @cf_client.delete_org(@org_id)
+      expect(@cf_client.get_org(@org_id)['error_code']).to eq('CF-OrganizationNotFound')
     end
   end
 
@@ -24,18 +53,66 @@ describe 'packages resource' do
   end
 
   describe 'PUT /packages/:guid', type: :integration do
-    context 'when package is uploaded', action: :upload do
-      it 'returns HTTP status 201' do
-        response = make_put_request resource_path, upload_body
-        expect(response.code).to eq 201
+    context 'without CC updater config' do
+      context 'when package is uploaded', action: :upload do
+        it 'returns HTTP status 201' do
+          response = make_put_request resource_path, upload_body
+          expect(response.code).to eq 201
+        end
+
+        it 'stores the blob in the backend' do
+          make_put_request resource_path, upload_body
+          expect(blobstore_client.key_exist?(guid)).to eq(true)
+        end
+
+        context 'when the request body is invalid', action: false do
+          let(:upload_body) { Hash.new }
+
+          it 'returns HTTP status 4XX' do
+            response = make_put_request resource_path, upload_body
+            expect(response.code).to eq 400
+          end
+        end
+
+        include_examples 'when blobstore disk is full', :packages
       end
 
-      it 'stores the blob in the backend' do
-        make_put_request resource_path, upload_body
-        expect(blobstore_client.key_exist?(guid)).to eq(true)
+      context 'when package is duplicated' do
+        context 'when the package exists', action: [:upload, :upload_existing] do
+          it 'returns HTTP status 201' do
+            response = make_put_request resource_path, JSON.generate(source_guid: existing_guid)
+            expect(response.code).to eq 201
+          end
+
+          it 'returns the guid and the package exists' do
+            make_put_request resource_path, JSON.generate(source_guid: existing_guid)
+            expect(blobstore_client.key_exist?(guid)).to eq(true)
+          end
+        end
+
+        context 'when the package does not exist' do
+          it 'returns the correct error' do
+            response = make_put_request resource_path, JSON.generate(source_guid: 'invalid-guid')
+            expect(response).to be_a_404
+          end
+        end
+
+        context 'when the body is invalid' do
+          it 'returns the correct error' do
+            response = make_put_request resource_path, 'foobar'
+            expect(response.code).to eq(400)
+          end
+        end
+
+        context 'when the body is empty' do
+          it 'returns the correct error' do
+            response = make_put_request resource_path, ''
+            expect(response.code).to eq(400)
+          end
+        end
       end
 
-      context 'when the request body is invalid', action: false do
+      context 'when the PUT is not a multipart request' do
         let(:upload_body) { Hash.new }
 
         it 'returns HTTP status 4XX' do
@@ -43,51 +120,20 @@ describe 'packages resource' do
           expect(response.code).to eq 400
         end
       end
-
-      include_examples 'when blobstore disk is full', :packages
     end
 
-    context 'when package is duplicated' do
-      context 'when the package exists', action: [:upload, :upload_existing] do
-        it 'returns HTTP status 201' do
-          response = make_put_request resource_path, JSON.generate(source_guid: existing_guid)
-          expect(response.code).to eq 201
-        end
-
-        it 'returns the guid and the package exists' do
-          make_put_request resource_path, JSON.generate(source_guid: existing_guid)
-          expect(blobstore_client.key_exist?(guid)).to eq(true)
-        end
-      end
-
-      context 'when the package does not exist' do
-        it 'returns the correct error' do
-          response = make_put_request resource_path, JSON.generate(source_guid: 'invalid-guid')
-          expect(response).to be_a_404
-        end
-      end
-
-      context 'when the body is invalid' do
-        it 'returns the correct error' do
-          response = make_put_request resource_path, 'foobar'
-          expect(response.code).to eq(400)
-        end
-      end
-
-      context 'when the body is empty' do
-        it 'returns the correct error' do
-          response = make_put_request resource_path, ''
-          expect(response.code).to eq(400)
-        end
-      end
-    end
-
-    context 'when the PUT is not a multipart request' do
-      let(:upload_body) { Hash.new }
-
-      it 'returns HTTP status 4XX' do
+    context 'with CC updater config', if: cc_updates_enabled? do
+      it 'does not allow to upload the same package twice' do
         response = make_put_request resource_path, upload_body
-        expect(response.code).to eq 400
+        expect(response.code).to eq(201), 'First upload should succeed'
+
+        # zip_file from upload_body is already closed by now, so we can't reuse it.
+        response = make_put_request resource_path, { package: File.new(zip_filepath) }
+        expect(response.code).to eq(400), 'Repeat upload should fail because package is already finalized'
+
+        err = JSON.parse(response)
+        expect(err['code']).to eq(290008)
+        expect(err['description']).to eq('Cannot update an existing package.')
       end
     end
   end

--- a/spec/signing_spec.rb
+++ b/spec/signing_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/cf.rb'
 
 describe 'URL Signing', type: :integration do
   let(:path) { "/packages/#{guid}" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require_relative 'support/response'
 require_relative 'support/http'
 require_relative 'support/file'
 require_relative 'support/manifest'
-require_relative 'support/cf.rb'
 
 RSpec.configure do |conf|
   include HttpHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require_relative 'support/response'
 require_relative 'support/http'
 require_relative 'support/file'
 require_relative 'support/manifest'
+require_relative 'support/cf.rb'
 
 RSpec.configure do |conf|
   include HttpHelpers

--- a/spec/support/cf.rb
+++ b/spec/support/cf.rb
@@ -1,0 +1,146 @@
+require 'base64'
+require 'json'
+
+module CFClient
+  class Client
+    def initialize(api_url, user, pass)
+      @api_url = api_url
+      @user = user
+      @pass = pass
+    end
+
+    def create_org
+      resp = make_post_request('/v2/organizations',
+        { name: random_name('testOrg') }.to_json
+      )
+      resp['metadata']['guid']
+    end
+
+    def delete_org(guid)
+      make_delete_request("/v2/organizations/#{guid}?recursive=true")
+    end
+
+    def get_org(guid)
+      make_get_request("/v2/organizations/#{guid}")
+    end
+
+    def create_space(parent_org_guid)
+      resp = make_post_request('/v2/spaces',
+        {
+          name: random_name('testSpace'),
+          organization_guid: parent_org_guid
+        }.to_json
+      )
+      resp['metadata']['guid']
+    end
+
+    def create_app(parent_space_guid)
+      resp = make_post_request('/v2/apps',
+        {
+          name: random_name('testApp'),
+          space_guid: parent_space_guid
+        }.to_json
+      )
+      resp['metadata']['guid']
+    end
+
+    def create_package(parent_app_guid)
+      resp = make_post_request('/v3/packages',
+        {
+          type: 'bits',
+          relationships: {
+            app: {
+              data: {
+                guid: parent_app_guid
+              }
+            }
+          }
+        }.to_json
+      )
+      resp['guid']
+    end
+
+    private
+
+    def login_url
+      return @login_url if @login_url
+      resp = RestClient::Request.execute({
+        url: "#{@api_url}/v2/info",
+        method: :get,
+        headers: { accept: :json },
+        verify_ssl: false
+      })
+      resp_hash = JSON.parse(resp)
+      @login_url = resp_hash['token_endpoint']
+    end
+
+    def fetch_token
+      body = "username=#{@user}&password=#{@pass}&client_id=cf&grant_type=password&response_type=token"
+      resp = RestClient::Request.execute(
+        method: :post,
+        url: "#{login_url}/oauth/token",
+        verify_ssl: false,
+        user: 'cf', pass: '',
+        payload: body
+      )
+      resp_hash = JSON.parse(resp)
+      resp_hash['access_token']
+    rescue RestClient::Exception => e
+      e.response
+    end
+
+    def make_get_request(path)
+      make_authorized_request(
+        method: :get,
+        url: url(path),
+      )
+    end
+
+    def make_delete_request(path)
+      make_authorized_request(
+        method: :delete,
+        url: url(path),
+      )
+    end
+
+    def make_post_request(path, body)
+      make_authorized_request(
+        method: :post,
+        url: url(path),
+        payload: body,
+      )
+    end
+
+    def make_authorized_request(args={})
+      resp = RestClient::Request.execute({
+        verify_ssl: false,
+        headers: {
+          'Authorization' => "Bearer #{auth_token}",
+          'Content-type' => 'application/json'
+          }
+      }.merge(args))
+      if resp.empty?
+        {}
+      else
+        JSON.parse(resp)
+      end
+    rescue RestClient::Exception => e
+      JSON.parse(e.response)
+    rescue JSON::ParserError => e
+      raise "JSON parsing failed: #{e.message}"
+    end
+
+    def url(path)
+      "#{@api_url}#{path}"
+    end
+
+    def auth_token
+      @auth_token ||= fetch_token
+    end
+
+    def random_name(base_name)
+      suffix = (0...8).map { ('a'..'z').to_a[rand(26)] }.join
+      base_name + '-' + suffix
+    end
+  end
+end

--- a/spec/support/manifest.rb
+++ b/spec/support/manifest.rb
@@ -51,4 +51,34 @@ module ManifestHelpers
     config = fog_config(resource_type)
     config['provider'].downcase
   end
+
+  def cc_updates_enabled?
+    cc_updates = manifest['properties']['bits-service']['cc_updates']
+    !cc_updates.nil? &&
+    !cc_updates['ca_cert'].to_s.empty? &&
+    !cc_updates['client_cert'].to_s.empty? &&
+    !cc_updates['client_key'].to_s.empty?
+  end
+
+  def test_properties
+    manifest['properties']['bits_service_tests']
+  end
+
+  def cc_api_url
+    test_properties['api']
+  rescue NoMethodError
+    raise 'Bits-service test configuration is missing: api'
+  end
+
+  def cc_user
+    test_properties['user']
+  rescue NoMethodError
+    raise 'Bits-service test configuration is missing: user'
+  end
+
+  def cc_password
+    test_properties['password']
+  rescue NoMethodError
+    raise 'Bits-service test configuration is missing: password'
+  end
 end

--- a/spec/upload_limit_spec.rb
+++ b/spec/upload_limit_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/cf.rb'
 
 describe 'Upload limits for resources' do
   before :all do

--- a/standalone.md
+++ b/standalone.md
@@ -6,7 +6,7 @@ In order to run tests against a standalone bits-service (deployed without Cloud 
 
     When targeting an S3 blobstore, the following environment variables are required to be set. Otherwise you can skip this step.
 
-      ```
+      ```sh
       export BITS_DIRECTORY_KEY=
       export AWS_ACCESS_KEY_ID=
       export AWS_SECRET_ACCESS_KEY=

--- a/standalone.md
+++ b/standalone.md
@@ -4,32 +4,34 @@ In order to run tests against a standalone bits-service (deployed without Cloud 
 
 1. Configure environment:
 
-  * When targeting an S3 blobstore, the following environment variables are required to be set. Otherwise you can skip this step.
+    When targeting an S3 blobstore, the following environment variables are required to be set. Otherwise you can skip this step.
 
-    ```
-    export BITS_DIRECTORY_KEY=
-    export AWS_ACCESS_KEY_ID=
-    export AWS_SECRET_ACCESS_KEY=
-    export BITS_AWS_REGION=
-    ```
+      ```
+      export BITS_DIRECTORY_KEY=
+      export AWS_ACCESS_KEY_ID=
+      export AWS_SECRET_ACCESS_KEY=
+      export BITS_AWS_REGION=
+      ```
 
 1. Generate manifest with tests stubs:
 
-  * For local:
-  ```
-  ./scripts/generate-test-bosh-lite-manifest-local
-  ```
+    * For local:
+      ```
+      ./scripts/generate-test-bosh-lite-manifest-local
+      ```
 
-  * For webdav:
-  ```
-  ./scripts/generate-test-bosh-lite-manifest-webdev
-  ```
+    * For webdav:
+      ```
+      ./scripts/generate-test-bosh-lite-manifest-webdev
+      ```
 
-  * For S3:
-  ```
-  ./scripts/generate-test-bosh-lite-manifest-s3
-  ```
+    * For S3:
+      ```
+      ./scripts/generate-test-bosh-lite-manifest-s3
+      ```
 
 1. Deploy the release using the generated manifest
 
 1. Refer to the README.md on how to run tests.
+
+    Make sure to point `BITS_SERVICE_PRIVATE_ENDPOINT_IP` to your bits-service VM. Also, you don't need to patch your `/etc/hosts` since standalone manifests use xip.io for addressing.

--- a/templates/bits_service_tests.yml
+++ b/templates/bits_service_tests.yml
@@ -1,0 +1,5 @@
+properties:
+  bits_service_tests:
+    api: https://api.bosh-lite.com
+    user: admin
+    password: admin

--- a/templates/mutual_tls.yml
+++ b/templates/mutual_tls.yml
@@ -1,0 +1,87 @@
+properties:
+  bits-service:
+    cc_updates:
+      ca_cert: |+
+        -----BEGIN CERTIFICATE-----
+        MIIE/TCCAuegAwIBAgIBATALBgkqhkiG9w0BAQswEDEOMAwGA1UEAxMFYmJzQ0Ew
+        HhcNMTUwOTE1MjIyOTE4WhcNMjUwOTE1MjIyOTIxWjAQMQ4wDAYDVQQDEwViYnND
+        QTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKjxJkuxVD5jrls2jXfB
+        ZsWd3HisgpdpgrTObOeJnrb6g4BB7GOSqMlZDEl0ROEBuT4Ax+tSEyhO8FgDR6Mq
+        Ey8h/HyOmCOsxt+0ZOlgmY04eGrSgkzhG41UiBEkezgFdxNCB8NZjTwwQmO2qjM7
+        BsTS9SaEh11HdpIhoeu22aqXuP0r56ZaRC7rfPb+U9SaWaygwMfgXZ7ZDBizHz+n
+        gRSvQ+KnvHG1nZGR+vwuNikBdby8YRBVXaGjF1I7uZh/kcPm2XX9RwHaXSIgGyuK
+        C+YJy95L4WdX2sgm8Mm+mhIKRnGggBbmUmbDT8URkYIu11YEI/FqH/+WmEPv0UC7
+        U1rSVkQVhlHgO6Ohjoe251jw9U1UR0qXsfI/2maPESxJW2FDXOrBCzMK0/Us+y7M
+        rBRLhLkYJmv9GUFQG1M3eOfP6VIMMm6wZ1+2untcI7Eb+HZxhO91ddYlKNbFpZ7P
+        f0P0GuopPE6kzX3gFoivEHxIslumeoVDgMzQ4uj1TYGmOtjuiD48kIrVaeEKUcxN
+        7YzSt3tTZ+a1GKqFcuj+g/rbUYLBT5Ztj89O3AahnCzCymOJ3EkWQ4aJzdAs3KEG
+        RxGs2zzsBKkTp+UXXv4q/GrZ+J/PjqY9285TaQx3MZmdLdIyNoh6UwwFPdyEYsTv
+        xhtJb5NdjY9K56mkeVEkfuGtAgMBAAGjZjBkMA4GA1UdDwEB/wQEAwIABjASBgNV
+        HRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTYcWew/0k5ZG8q8OzlhKSPH6v8szAf
+        BgNVHSMEGDAWgBTYcWew/0k5ZG8q8OzlhKSPH6v8szALBgkqhkiG9w0BAQsDggIB
+        AFt3ueVxYhu5vT1IKL/xIuxfl8SXZqaJSg35DqJ6FlEDU+E/mjflrPMsV5Iz5ycd
+        JMO3hN9ipilkfx5m7gTIDcxl0izej2jlI2uncjLT6MsPI1+LsRxyVDR4+MDvM7ce
+        myfpIPNQlGQI/cTkmOT+tTaffwf6PLcvT/HvJivax/y0tIsCIqtTSoM6eoi6D9jN
+        n/VkMsZpaxxIt0nm87ZgcWA6IVPdtO51eLWlJyfz8/V8f/ySARUMdMSVkFiS6OMS
+        nxsrQGPLOOWTYepV6XD4GP9zDYL4aLArGfWprq79KHAtRYtGHixgcxFgbfBnon2y
+        6HG1vDa/sVFrleSwBRsCtVRgYvAShdn50hL4JgSn8OjkkTVB1wz74bqCj001RHfS
+        dxKhfzBPQsqsdGCMZKkRGUpUavM3qW/UAxbYgkjcS04hzmjyC/I1sKpDebQJyX9i
+        66F3zR7eRzwH7Y8s5PTo+dYZJmNxtN7vJKq++8Cg707XUzBT/U2SQV84TOsZO70Q
+        Hl7GKY3NdpVEslyiwMdi6DyhTH+MV3HMkEds16wCRNAVriSXPeg/GYNhQqcdTceU
+        I0YSumzEeQMcFbg0LUYayZ9PlhPgLosMba9BDK/K244OZvmGyRr1ANnnASsQg4cK
+        vsHDEV4jBWxHAw41ArfNLg9vA8ojf/1EU4E2d5GU5fVe
+        -----END CERTIFICATE-----
+      client_key: |+
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEAxGbcfonAONXE16jy7+PKJu4hZH7oWQ6GSll75CVeQIMbDIoN
+        m79dmhk7rPVCl3V71iGJw6iKPHziKlXsO1eK7QRKhHKmBBPwy5yeKoGZIb2vF7C2
+        rsa24i2Woz3QPFv62j6SBJnE5rBaexiHv53stFS5Yroa/Vg+65DT+D7tvallTuXS
+        m6OgFeEjgPIlDw1To0FlizOWapfynFbaMvTAdCVrNAVHcCvL7/QwSFwEHZGargPS
+        r9vLYj6E/NuT/W0GcMi7AEX6zYbs7tk/lP9UtBpoX1FrLVnPIQe9UXAfxaD3CL5y
+        9sF3sPZRnvEdnaB99XjSB/AEtCIfvaGOaOwDjQIDAQABAoIBAG+BVr4gxxl9hHxM
+        V2ELGsJvgFXmF1Q4gtXDaCtna9OEm97Kol9CjonmuZLAzEXhVaWE9Qo4rgMZg+41
+        SiGG2kEmpof773VxPMzc5o+LdL1LTBVPJuijuUFAUL3tYkRilFFEJPKnurqedUBd
+        9PQ9XR4k2/vJXXlomJB1cWMHl0KN4fE1dceSedgk87Qj+/HdQDQ+SzfAu/xhNp0R
+        MogacY2PgpIWlyxPIiFNQ3mqudoLq0Xu+ujqrTMWIn3NRLAAknC6QRXBCkhTyK2t
+        bJFMnp3RQ1phs5ouoNI9eMa2l7QAnvJ27uSSQWqnEoFQZAmzxQw8Sxxhr96qLKGd
+        Va/LcAECgYEA+fN6WVbL8/zUWxEEVFFSeSOEJq1ajtDrlYjq2f9pItaSzMMQvjYm
+        4+KUc2dWCAkedVJvhstNvdq44Nkt3BWEDyfA/dXfhP2ArhsKtXUmWAmAwnMWHD9v
+        JfTvlnSL/qC5wEvrpixkC0mRAXyCCD8sg8COziASkyDTrooN10fodg0CgYEAySeh
+        JYP5Swp429wIkK/n+UHT0QQvT0jkGbdkoL/sUB3QJ6ZWgIKTeczed2xm46nZwzT6
+        uUMGAI4MkMrlyfp6XrM6lc+C6qg+DQ81yGK3IwOMfC0JSgEAN3McNEOoo9nS4g/X
+        W+4wd9GfkSLozKTodGZVIZ+sCrMbSRrZg2jH44ECgYBHNod1TLVvHmmiSIbjPwgw
+        W14bZuiWKA/22ruOwKZDtr68eBcdGnCaHMQO3TI1t+Nlqcb8sI/Ft7tU1IusWLT3
+        XGwv5e95BIDVGf9DE82I56w3unJiOfCA7/gS9cGtGj3R+8932M3oKV2W/tJNZzJX
+        l1UYhSrFoGSvJcYrv+ELQQKBgBOOytg+8KofJokZ56tJryBJCjM0WPU4fRUTA7Gt
+        d2iCvY5dWeO8zmH1TVwHKinQhd+48ve4UIkVRpt9XsI4nFVAz91pA62VFhNm+y+0
+        iWHaInqgVlrfpgm+I2vheDAWKa7ZI3NIwWWk+ALAhin/jqpimLxgLfYMXAbLmYJx
+        WZ4BAoGBAPMeCcOlKHbIk8Wk/dDZFcYVKpCEGPtdSOIinZic538DLXY5isoR8dju
+        EXu9DMlHZdv1pMULzgc6imIxXwHR9w7Ewkd3JbRtrAKltD9fpmf6Nsu54EISdaHr
+        Ef83RyOgYBiHGeeG+xXbCmTjDF0uJxl/F6w+cwisGsykK+5FGpPN
+        -----END RSA PRIVATE KEY-----
+      client_cert: |+
+        -----BEGIN CERTIFICATE-----
+        MIIEIzCCAgugAwIBAgIRAPomjV9BCfK1+gqCBqZiv+QwDQYJKoZIhvcNAQELBQAw
+        EDEOMAwGA1UEAxMFYmJzQ0EwHhcNMTcwNzI2MTIwMjE1WhcNMTkwNzI2MTIwMjE1
+        WjAXMRUwEwYDVQQDEwxiaXRzLXNlcnZpY2UwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+        DwAwggEKAoIBAQDEZtx+icA41cTXqPLv48om7iFkfuhZDoZKWXvkJV5AgxsMig2b
+        v12aGTus9UKXdXvWIYnDqIo8fOIqVew7V4rtBEqEcqYEE/DLnJ4qgZkhva8XsLau
+        xrbiLZajPdA8W/raPpIEmcTmsFp7GIe/ney0VLliuhr9WD7rkNP4Pu29qWVO5dKb
+        o6AV4SOA8iUPDVOjQWWLM5Zql/KcVtoy9MB0JWs0BUdwK8vv9DBIXAQdkZquA9Kv
+        28tiPoT825P9bQZwyLsARfrNhuzu2T+U/1S0GmhfUWstWc8hB71RcB/FoPcIvnL2
+        wXew9lGe8R2doH31eNIH8AS0Ih+9oY5o7AONAgMBAAGjcTBvMA4GA1UdDwEB/wQE
+        AwIDuDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHQYDVR0OBBYEFPEh
+        TprNLF51xSMcItZcWAWYRg/1MB8GA1UdIwQYMBaAFNhxZ7D/STlkbyrw7OWEpI8f
+        q/yzMA0GCSqGSIb3DQEBCwUAA4ICAQA/s10RwYEQptl0ae5x8yrQq3WBgZl7wV/l
+        a4g7NWJnv9sUGOLrF0Xwk/WvIcATl9NemxaubQujFc0z5UlS/MkmNgbkSlNnEbqC
+        NFx2Tsyi4SAd+KaIGwXq0tb2veIDQPQwTFNPykgk+QoUOVs+Afo7yvfp5hnXDR2o
+        8McoxstpYpgk9sYJNGJJo1HZOV7KqYsuC5BJ1vfYF9uznXc72LyCOVpXwRDLFKrh
+        bbXG4zZKRUR2RTvyblLpRdMFgbilCAu3/3C9dmX5O3jV0Hjxre6gmqCZFYFG9Kda
+        vgu22mh+Tj9FwZAot/VCltowc/D84kT7mSo35q5MdzNaeiiwgpzzDdmGDCahO6Zg
+        pbDCix1/E1r0EHyDEIf+RjqLxmoU9ouJ7qGw8PFJvSPdEw9VRLL9PUw3KGblTAm7
+        qGKpefbdK8dKdXlg1fLtx7JZkhGOD5iN6fGa6zzw1GiADFDo9Zevh3ocCvchgKDY
+        xymZR07UvUKU7dDW8j5YY9Pe5Qn+awqvxIBWCkwW4gvwvqIxtxcR9qYB99T6zVpc
+        DsldVkSew2Kk0afmYCO3O/I3el52urzkGqA+PUSOws3ns9gTlRdndH/LRHYDnBqM
+        ef5ZVAgyGIP+O6kKaH3Ijs9zzsspAAj2xQjzkproWl082Q6nnNBEwAuLLkJQ7gqY
+        KkDyk6ZIxQ==
+        -----END CERTIFICATE-----


### PR DESCRIPTION
Bits-service is now able to report package status to CloudController through an
encrypted channel with client key checking (Mutual TLS).

It is still possible to run bits-service standalone when CCUpdater config part
is missing. The new config subtree is called `bits-service.cc_updates`.

When CC updates are enabled, special setup within CC is performed to allow
the intergration tests to run properly. When CCUpdater is not configured, the
setup is skipped.

[#143968055] [#143967581]

Signed-off-by: Alexander Egurnov <egurnov@de.ibm.com>
Signed-off-by: Steffen Uhlig <Steffen.Uhlig@de.ibm.com>
Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>