### PR TITLE
Expose registry_endpoint

### DIFF
--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -257,3 +257,11 @@ properties:
   bits-service.proxy_get_requests:
     description: "When set to true, GET requests get proxied through Bits-Service and not redirected to the backend blobstore (such as S3)"
     default: false
+
+  bits-service.registry_endpoint:
+    description: "Docker registry endpoint"
+  bits-service.enable_registry:
+    description: "When set to true, the configured registry it's used"
+    default: false
+  bits-service.rootfs.blobstore_type:
+    descriptioon: "The type of blobstore backing to use."

--- a/jobs/bits-service/templates/bits_config.yml.erb
+++ b/jobs/bits-service/templates/bits_config.yml.erb
@@ -403,3 +403,14 @@ active_key_id: <%= p("bits-service.active_signing_key.key_id") %>
 <% end %>
 
 proxy_get_requests: <%= p("bits-service.proxy_get_requests") %>
+
+enable_registry: <%= p("bits-service.enable_registry") %>
+<% if_p("bits-service.registry_endpoint") do | registry | %>
+registry_endpoint: <%= registry %>
+<% end %>
+<% if p("bits-service.rootfs.blobstore_type") != '' && p("bits-service.rootfs.blobstore_type") != nil %>
+rootfs:
+  blobstore_type: <%= p("bits-service.rootfs.blobstore_type") %>
+  local_config:
+    path_prefix: /var/vcap/store/bits-service/
+<% end %>


### PR DESCRIPTION
Needed for Eirini support

We have this patch: https://github.com/SUSE/scf/blob/develop/container-host-files/etc/scf/config/scripts/patches/bits_add_missing_config_keys.sh#L15 which we would like to upstream. 

Any feedback / comment is welcome.

Also, is there something that I can help with to add tests for this change? 