### PR TITLE
Fix containerPort for bits-service

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -116,7 +116,7 @@ spec:
         image: flintstonecf/bits-service:2.26.0-dev.8
         imagePullPolicy: Always
         ports:
-          - containerPort: 4443
+          - containerPort: 8888
         volumeMounts:
         - name: bits-config
           mountPath: /workspace/jobs/bits-service/config


### PR DESCRIPTION
Hi, I would like to give some of my backgrounds. I wanted to use istio to track scf+eirini. Then I found an issue when enabling istio. The sidecars(istio-proxy) of bits pods could not be ready because they tried to check ports 4443 and failed to get responses: envoy missing listener for inbound application port: 4443 So I changed pod template because this port 8888 is hardcoded in bis [config](https://github.com/cloudfoundry-incubator/bits-service-release/blob/master/helm/bits/templates/bits.yaml#L28).

So it's better to correct port about what bits want to expose.

Thanks
