### PR TITLE
Copy last changes in pod definition

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -134,7 +134,6 @@ spec:
         volumeMounts:
         - name: bits-assets
           mountPath: /assets/
-        restartPolicy: "OnFailure"
 
 # Service
 ---


### PR DESCRIPTION
last commit on bits helm chart was on eirini-release. I am just replicating those changes here. 39ec56e82d4131635fe09fb3a381d95445c801dc was the commit in eirini-release to remove `restart policy` from pod definition.