### PR TITLE
Restart policy is not part of the container spec

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -111,6 +111,7 @@ spec:
           hostPath:
             path: /bits/assets/
             type: DirectoryOrCreate
+      restartPolicy: "OnFailure"
       containers:
       - name: bits
         image: flintstonecf/bits-service:2.26.0-dev.8
@@ -134,7 +135,6 @@ spec:
         volumeMounts:
         - name: bits-assets
           mountPath: /assets/
-        restartPolicy: "OnFailure"
 
 # Service
 ---


### PR DESCRIPTION
Hello all. I moved `restartPolicy` from container spec to the pod spec, because `helm install`ing fails with:

```
Error: validation failed: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0]): unknown field "restartPolicy" in io.k8s.api.core.v1.Container
``` 


This PR must be merged before we can merge https://github.com/cloudfoundry-incubator/eirini-release/pull/78.

BR,
Georgi

/cc @kiranjain2 
