### PR TITLE
Add BPM support

### DIFF
--- a/jobs/bits-service/monit
+++ b/jobs/bits-service/monit
@@ -1,5 +1,13 @@
+<% if p("bpm.enabled") %>
+check process bits-service
+  with pidfile /var/vcap/sys/run/bpm/bits-service/bits-service.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start bits-service"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop bits-service"
+  group vcap
+<% else %>
 check process bits-service
   with pidfile /var/vcap/sys/run/bits-service/bits-service.pid
   start program "/var/vcap/jobs/bits-service/bin/bits-service_ctl start"
   stop program "/var/vcap/jobs/bits-service/bin/bits-service_ctl stop"
   group vcap
+<% end %>

--- a/jobs/bits-service/spec
+++ b/jobs/bits-service/spec
@@ -8,6 +8,7 @@ templates:
   dashboard.erb:           bin/dashboard
 
   bits_config.yml.erb:        config/bits_config.yml
+  bpm.yml.erb:                config/bpm.yml
   signing_users.erb:          config/signing_users
   app_stash_ca_cert.pem.erb:  config/certs/app_stash_ca_cert.pem
   buildpacks_ca_cert.pem.erb: config/certs/buildpacks_ca_cert.pem
@@ -31,6 +32,10 @@ provides:
   - 'bits-service.active_signing_key.secret'
 
 properties:
+  bpm.enabled:
+    description: "Enable BOSH Process Manager"
+    default: false
+
   request_timeout_in_seconds:
     description: "Timeout for requests in seconds."
     default: 900

--- a/jobs/bits-service/templates/bits_config.yml.erb
+++ b/jobs/bits-service/templates/bits_config.yml.erb
@@ -369,7 +369,7 @@ logging:
   level: <%= p("bits-service.logging.level") %>
 private_endpoint: <%= p("bits-service.private_endpoint") %>
 public_endpoint: <%= p("bits-service.public_endpoint") %>
-port: 443
+port: <%= p("bits-service.tls.port") %>
 <%
   if p("bits-service.secret", "") == '' && p("bits-service.active_signing_key.secret", "") == ''
     raise 'Must either provide bits-service.secret or bits-service.active_signing_key.secret'

--- a/jobs/bits-service/templates/bpm.yml.erb
+++ b/jobs/bits-service/templates/bpm.yml.erb
@@ -1,0 +1,9 @@
+processes:
+- name: bits-service
+  executable: /var/vcap/packages/bitsgo/bitsgo
+  args:
+  - -c
+  - /var/vcap/jobs/bits-service/config/bits_config.yml
+  capabilities:
+  - NET_BIND_SERVICE
+  persistent_disk: true


### PR DESCRIPTION
Hello bits-service folks,

Adding BPM support to prevent bits-service process from running unnecessarily as root. Appears that the process is currently running in a privileged manner to bind on a privileged port (443).

Given that BPM has de-escalated privileges, it cannot bind the bits-service process to port 443 by default, so we configured BPM to run our process with the `NET_BIND_SERVICE` file capability so that it can bind the bits-service process on port 443.

We also were wondering if it would be possible to remove non-BPM support in this or a separate PR since some other CF components have dropped support for the `_ctl` script flows? 

Please let us know if there are any issues or if there are any other reasons that requires the bits-service process to run as root. 

Thanks,

@madamkiwi && @jspawar