### PR TITLE
Set correct restartPolicy for Bits deployment

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -111,7 +111,6 @@ spec:
           hostPath:
             path: /bits/assets/
             type: DirectoryOrCreate
-      restartPolicy: "OnFailure"
       containers:
       - name: bits
         image: flintstonecf/bits-service:2.26.0-dev.8


### PR DESCRIPTION
This is a follow-up on #26

Turns out for Deployments the only allowed value for `restartPolicy` is `Always`, which is the default if not specified.

Sorry for the oversight. 😞 

Best regards,
Georgi