### PR TITLE
http proxy for eirini-rootfs-downloader

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -128,6 +128,12 @@ spec:
         env:
         - name: EIRINI_ROOTFS_VERSION
           value: {{ .Values.opi.rootfs_version }}
+          {{- if .Values.env.eirinifs_downloader_http_proxy }}
+        - name: http_proxy
+          value: "{{ .Values.env.eirinifs_downloader_http_proxy }}"
+        - name: https_proxy
+          value: "{{ .Values.env.eirinifs_downloader_http_proxy }}"
+          {{- end }}
         command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
         volumeMounts:
         - name: bits-assets

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -23,3 +23,4 @@ env:
   # Base domain of the SCF cluster.
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
+  eirinifs_downloader_http_proxy: ~


### PR DESCRIPTION
Add an option to specify http proxy for download-eirini-rootfs init container.