### PR TITLE
opi.use_registry_ingress without kube.external_ips

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -9,10 +9,12 @@ data:
     logging:
       level: debug
     private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
-    {{- if .Values.services.loadbalanced }}
-    public_endpoint: https://registry.{{ .Values.env.DOMAIN }}:6666
+    {{- if .Values.opi.use_registry_ingress }}
+    public_endpoint: "https://registry.{{ .Values.opi.ingress_endpoint }}:443"
+    {{- else if .Values.services.loadbalanced }}
+    public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:6666"
     {{- else }}
-    public_endpoint: https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io
+    public_endpoint: "https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}
     {{- if .Values.opi.use_registry_ingress }}
     registry_endpoint: "https://registry.{{ .Values.opi.ingress_endpoint }}"


### PR DESCRIPTION
As can be seen in https://github.com/cloudfoundry-incubator/eirini-release/blob/e83a94cf628d8cd7fd75d1058ce7ea66c21372bc/helm/eirini/templates/job-secret-smuggler.yaml#L30-L36, SCF and eirini work specifying `opi.use_registry_ingress` but without also specifying `kube.external_ips` at the same time.

This scenario is useful when Kubernetes clusters are auto-scaling or for other reasons changing their IPs and adapting the list of IPs is not feasible.