### PR TITLE
feat: Support arbitrary labels and annotations for bits deployment object

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -90,6 +90,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "bits"
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   replicas: 1
   selector:

--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -99,9 +99,13 @@ spec:
     metadata:
       labels:
         name: "bits"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       volumes:

--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -99,6 +99,9 @@ spec:
     metadata:
       labels:
         name: "bits"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       volumes:

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -13,6 +13,8 @@ blobstore:
 
 global:
   rootfs_version: v129.0.0
+  label: {}
+  annotations: {}
 
 tls_secret_name: private-registry-cert
 # set to true if you wish to use a pre-populated


### PR DESCRIPTION
See ticket https://github.com/cloudfoundry-incubator/kubecf/issues/795

The feature is needed to set/control annotations for quarks operator restart behavior, and for identification labels, when used as part of a larger system, i.e. kubecf.

- Extended values.yaml with keys for user labels and annotations,
  plus defaults (no user labels, no user annotations).
- Interpolate the new keys into the proper place of the deployment
  (spec.template.metadata).

The change was manually tested using the `helm template` command and a custom additional values.yaml providing required values and some user-specified labels and annotations. The result was inspected to properly contain these labels and annotations.

```
% pwd
(...)/bits-service-release--ak/helm

% cat ../../x.yaml
# Fakes for required values.
kube:
  external_ips:
  - 10.10.0.1
secrets:
  BITS_TLS_CRT: "fubar"
  BITS_TLS_KEY: "snafu"
# User-specified labels, annotations
global:
  labels:
    hello: kubecf_795
  annotations:
    hello: kubecf_795

% helm template foo eirini --values ../../x.yaml | less
# look for 795.
```
