### PR TITLE
Allow users to skip the eirinifs downloading init container.

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -132,12 +132,15 @@ spec:
           mountPath: /workspace/jobs/bits-service/config
         - name: bits-cert
           mountPath: /workspace/jobs/bits-service/certs
+        {{- if .Values.download_eirinifs }}
         - name: bits-assets
           mountPath: /assets/
+        {{ end }}
         resources:
           requests:
             cpu: 800m
             memory: 150Mi
+      {{- if .Values.download_eirinifs }}
       initContainers:
       - name: "download-eirini-rootfs"
         image: eirini/rootfs-downloader:2.32.0@sha256:6ae511688a27a453dcf31bf5a3bd7287ba99233e1586c7aeb78c87a18c68dbe4
@@ -160,6 +163,7 @@ spec:
             memory: 50Mi
       securityContext:
         runAsNonRoot: true
+      {{ end }}
 
 # Service
 ---

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -20,6 +20,10 @@ tls_secret_name: private-registry-cert
 # cert-manager
 useExistingSecret: false
 
+# If set to false, the eirinifs will not be downloaded when the bits pod
+# is started. It should be used when the eirinifs is provided in some other way.
+download_eirinifs: true
+
 kube:
   external_ips: []
 


### PR DESCRIPTION
In such a case, the user should make sure the /assets/eirinifs.tar file
is there. E.g. by using a bits image that has it included.

Unblocks: https://github.com/cloudfoundry-incubator/kubecf/issues/476

Signed-off-by: Dimitris Karakasilis <dkarakasilis@suse.com>